### PR TITLE
Adds star rating functionality to the dial controls and fixes several overlay display bugs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v1.2.0
+
+### New Features
+- **Star Rating dial action**: New "Rotate: Star Rating" option for the dial. Scroll to adjust the current track's rating (0-5 stars). Supports both half-star and full-star modes.
+  - **Half Star mode**: Each scroll increments by 0.5 stars (★⯨☆☆☆)
+  - **Full Star mode**: Each scroll increments by 1.0 stars (★★☆☆☆)
+  - Visual overlay shows star rating with Unicode stars during adjustment
+  - **Debounced saving**: Rating saves 2 seconds after you stop rotating, letting you adjust freely before committing
+  - **Success confirmation**: "SAVED!" overlay appears when rating is successfully saved to Plex
+  - Ratings are saved directly to Plex server and persist across library
+  - Current track ratings are loaded and displayed when tracks change
+- **Rating mode setting**: New dropdown to choose between half-star and full-star rating increments (only appears when rating dial action is selected)
+- **Error feedback**: API errors (missing server config, authentication failures, etc.) are displayed directly on the strip
+
+### Bug Fixes
+- **Fixed overlay display reversion**: Strip overlays (volume, rating, next/prev) now properly clear and revert to the original display mode after 1.5 seconds. Corrected layout geometry that was causing element overlap errors.
+- **Fixed layout overlap errors**: Adjusted touch strip layout positioning to prevent `progressBar` and `displayText` element conflicts
+
+### Technical Notes
+- Current track rating is extracted from timeline metadata (`userRating` attribute, 0-10 scale where 0=unrated, 2=1★, 10=5★)
+- Rating updates use Plex's `/:/rate` API endpoint with the track's ratingKey
+- Rating overlay uses Unicode characters: ★ (filled), ☆ (empty), ⯨ (half)
+- Debounce timer prevents multiple API calls while user is adjusting rating
+- Rating changes are protected from being overwritten by timeline polls for 3 seconds after user adjustment
+- Plexamp UI may not immediately reflect rating changes due to caching; skip forward/back to refresh
+
 ## v1.1.0
 
 ### Major Changes

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Ampdeck brings Plexamp to your Stream Deck. See your album art, track info, and 
 
 - **Album Art** — Live album art on any LCD key with a pause overlay. Tap to play/pause.
 - **Now Playing Strip** — Artist, album, track, or elapsed time on each touch strip panel with auto-scrolling for long text.
-- **Dial Controls** — Configurable dial actions: rotate to skip tracks or adjust volume. Press to play/pause, toggle shuffle, or cycle repeat.
+- **Dial Controls** — Configurable dial actions: rotate to skip tracks, adjust volume, or rate tracks. Press to play/pause, toggle shuffle, or cycle repeat.
+- **Star Ratings** — Rate your tracks with half-star or full-star increments using the dial. Visual feedback shows the rating with stars.
 - **Touch Strip Controls** — Tap to play/pause with visual feedback overlays showing the action taken.
 - **Spanning Progress Bar** — A single progress bar that flows across all 4 dials, with colors extracted from album art.
 - **Play / Pause** — Dedicated button with instant visual feedback.
@@ -111,7 +112,8 @@ Each dial panel can be configured independently:
 |---------|---------|
 | **Display Mode** | Artist, Album, Track Title, or Time |
 | **Font Size** | Small (12) through XX-Large (28) |
-| **Dial Action** | None, Next/Previous (rotate), or Volume (rotate) |
+| **Dial Action** | None, Next/Previous (rotate), Volume (rotate), or Star Rating (rotate) |
+| **Rating Mode** | Half Star (0.5 increment) or Full Star (1.0 increment) — only appears when Dial Action is set to Star Rating |
 | **Dial Press** | Play/Pause, Toggle Shuffle, or Cycle Repeat |
 | **Total Panels** | How many panels share the progress bar (1–4) |
 | **Panel Position** | This panel's position in the progress bar sequence, or None to disable |

--- a/com.rackemrack.ampdeck.sdPlugin/manifest.json
+++ b/com.rackemrack.ampdeck.sdPlugin/manifest.json
@@ -6,7 +6,7 @@
   "Name": "Ampdeck",
   "Icon": "imgs/plugin-icon",
   "URL": "https://plex.tv",
-  "Version": "1.1.0",
+  "Version": "1.2.0",
   "Category": "Ampdeck",
   "CategoryIcon": "imgs/category-icon",
   "OS": [

--- a/com.rackemrack.ampdeck.sdPlugin/pi-strip.html
+++ b/com.rackemrack.ampdeck.sdPlugin/pi-strip.html
@@ -135,8 +135,18 @@
             <option value="none">None</option>
             <option value="skip">Rotate: Next/Previous, Press: Play/Pause</option>
             <option value="volume">Rotate: Volume, Press: Play/Pause</option>
+            <option value="rating">Rotate: Star Rating, Press: Play/Pause</option>
         </select>
         <div class="help-text">What the physical dial does when rotated</div>
+    </div>
+
+    <div class="sdpi-item" id="ratingModeContainer" style="display: none;">
+        <label>Rating Mode</label>
+        <select id="ratingMode">
+            <option value="half">Half Star (0.5 increment per scroll)</option>
+            <option value="full">Full Star (1.0 increment per scroll)</option>
+        </select>
+        <div class="help-text">How much each scroll changes the rating</div>
     </div>
 
     <div class="sdpi-item">
@@ -256,6 +266,7 @@
             document.getElementById('displayMode').value = settings.displayMode || 'artist';
             document.getElementById('fontSize').value = settings.fontSize || '16';
             document.getElementById('dialAction').value = settings.dialAction || 'none';
+            document.getElementById('ratingMode').value = settings.ratingMode || 'half';
             document.getElementById('dialPressAction').value = settings.dialPressAction || 'playpause';
             document.getElementById('progressTotalPanels').value = settings.progressTotalPanels || '3';
             document.getElementById('progressPosition').value = settings.progressPosition || '1';
@@ -267,6 +278,9 @@
             document.getElementById('clientName').value = settings.clientName || '';
             document.getElementById('syncOffset').value = settings.syncOffset !== undefined ? settings.syncOffset : 0;
             document.getElementById('debugMode').checked = settings.debugMode === true;
+            
+            // Show/hide rating mode based on dial action
+            updateRatingModeVisibility();
 
             websocket = new WebSocket('ws://127.0.0.1:' + inPort);
             
@@ -298,11 +312,18 @@
             };
         }
 
+        function updateRatingModeVisibility() {
+            const dialAction = document.getElementById('dialAction').value;
+            const ratingModeContainer = document.getElementById('ratingModeContainer');
+            ratingModeContainer.style.display = (dialAction === 'rating') ? 'block' : 'none';
+        }
+
         function saveSettings() {
             const settings = {
                 displayMode: document.getElementById('displayMode').value,
                 fontSize: document.getElementById('fontSize').value,
                 dialAction: document.getElementById('dialAction').value,
+                ratingMode: document.getElementById('ratingMode').value,
                 dialPressAction: document.getElementById('dialPressAction').value,
                 progressTotalPanels: document.getElementById('progressTotalPanels').value,
                 progressPosition: document.getElementById('progressPosition').value,
@@ -342,7 +363,11 @@
 
         document.getElementById('displayMode').addEventListener('change', saveSettings);
         document.getElementById('fontSize').addEventListener('change', saveSettings);
-        document.getElementById('dialAction').addEventListener('change', saveSettings);
+        document.getElementById('dialAction').addEventListener('change', function() {
+            updateRatingModeVisibility();
+            saveSettings();
+        });
+        document.getElementById('ratingMode').addEventListener('change', saveSettings);
         document.getElementById('dialPressAction').addEventListener('change', saveSettings);
         document.getElementById('progressTotalPanels').addEventListener('change', saveSettings);
         document.getElementById('progressPosition').addEventListener('change', saveSettings);

--- a/com.rackemrack.ampdeck.sdPlugin/pi-strip.html
+++ b/com.rackemrack.ampdeck.sdPlugin/pi-strip.html
@@ -318,7 +318,46 @@
             ratingModeContainer.style.display = (dialAction === 'rating') ? 'block' : 'none';
         }
 
+        function validateUrl(url, allowLocalHttp) {
+            if (!url) return { valid: true }; // Empty is ok
+            try {
+                const parsed = new URL(url);
+                if (!['http:', 'https:'].includes(parsed.protocol)) {
+                    return { valid: false, error: 'Only HTTP and HTTPS are allowed' };
+                }
+                if (parsed.protocol === 'http:' && !allowLocalHttp) {
+                    const isLocal = parsed.hostname === 'localhost' || 
+                                  parsed.hostname === '127.0.0.1' ||
+                                  parsed.hostname.startsWith('192.168.') ||
+                                  parsed.hostname.startsWith('10.') ||
+                                  parsed.hostname.startsWith('172.');
+                    if (!isLocal) {
+                        return { valid: false, error: 'HTTPS required for remote servers' };
+                    }
+                }
+                return { valid: true };
+            } catch (e) {
+                return { valid: false, error: 'Invalid URL: ' + e.message };
+            }
+        }
+
         function saveSettings() {
+            const playerUrl = document.getElementById('playerUrl').value.trim();
+            const serverUrl = document.getElementById('plexServerUrl').value.trim();
+            
+            // Validate URLs
+            const playerValidation = validateUrl(playerUrl, true);
+            const serverValidation = validateUrl(serverUrl, false);
+            
+            if (!playerValidation.valid) {
+                showStatus('error', 'Player URL: ' + playerValidation.error);
+                return;
+            }
+            if (!serverValidation.valid) {
+                showStatus('error', 'Server URL: ' + serverValidation.error);
+                return;
+            }
+            
             const settings = {
                 displayMode: document.getElementById('displayMode').value,
                 fontSize: document.getElementById('fontSize').value,
@@ -329,8 +368,8 @@
                 progressPosition: document.getElementById('progressPosition').value,
                 textColor: document.getElementById('textColor').value,
                 dynamicColors: document.getElementById('dynamicColors').checked,
-                playerUrl: document.getElementById('playerUrl').value.trim(),
-                plexServerUrl: document.getElementById('plexServerUrl').value.trim(),
+                playerUrl: playerUrl,
+                plexServerUrl: serverUrl,
                 plexToken: document.getElementById('plexToken').value.trim(),
                 clientName: document.getElementById('clientName').value.trim(),
                 syncOffset: parseInt(document.getElementById('syncOffset').value) || 0,
@@ -359,6 +398,12 @@
                     }
                 }));
             }
+        }
+        
+        function showStatus(type, message) {
+            const statusEl = document.getElementById('status');
+            statusEl.className = 'show ' + type;
+            statusEl.textContent = message;
         }
 
         document.getElementById('displayMode').addEventListener('change', saveSettings);
@@ -438,8 +483,11 @@
             statusEl.textContent = 'Testing server connection...';
 
             try {
-                const response = await fetch(serverUrl + '/status/sessions?X-Plex-Token=' + token, {
-                    headers: { 'Accept': 'application/json' }
+                const response = await fetch(serverUrl + '/status/sessions', {
+                    headers: { 
+                        'Accept': 'application/json',
+                        'X-Plex-Token': token
+                    }
                 });
 
                 if (!response.ok) throw new Error('HTTP ' + response.status);

--- a/com.rackemrack.ampdeck.sdPlugin/pi.html
+++ b/com.rackemrack.ampdeck.sdPlugin/pi.html
@@ -220,12 +220,51 @@
             };
         }
 
+        function validateUrl(url, allowLocalHttp) {
+            if (!url) return { valid: true }; // Empty is ok
+            try {
+                const parsed = new URL(url);
+                if (!['http:', 'https:'].includes(parsed.protocol)) {
+                    return { valid: false, error: 'Only HTTP and HTTPS are allowed' };
+                }
+                if (parsed.protocol === 'http:' && !allowLocalHttp) {
+                    const isLocal = parsed.hostname === 'localhost' || 
+                                  parsed.hostname === '127.0.0.1' ||
+                                  parsed.hostname.startsWith('192.168.') ||
+                                  parsed.hostname.startsWith('10.') ||
+                                  parsed.hostname.startsWith('172.');
+                    if (!isLocal) {
+                        return { valid: false, error: 'HTTPS required for remote servers' };
+                    }
+                }
+                return { valid: true };
+            } catch (e) {
+                return { valid: false, error: 'Invalid URL: ' + e.message };
+            }
+        }
+
         function saveSettings() {
+            const playerUrl = document.getElementById('playerUrl').value.trim();
+            const serverUrl = document.getElementById('plexServerUrl').value.trim();
+            
+            // Validate URLs
+            const playerValidation = validateUrl(playerUrl, true);
+            const serverValidation = validateUrl(serverUrl, false);
+            
+            if (!playerValidation.valid) {
+                showStatus('error', 'Player URL: ' + playerValidation.error);
+                return;
+            }
+            if (!serverValidation.valid) {
+                showStatus('error', 'Server URL: ' + serverValidation.error);
+                return;
+            }
+            
             const settings = {
                 textColor: document.getElementById('textColor').value,
                 dynamicColors: document.getElementById('dynamicColors').checked,
-                playerUrl: document.getElementById('playerUrl').value.trim(),
-                plexServerUrl: document.getElementById('plexServerUrl').value.trim(),
+                playerUrl: playerUrl,
+                plexServerUrl: serverUrl,
                 plexToken: document.getElementById('plexToken').value.trim(),
                 clientName: document.getElementById('clientName').value.trim(),
                 syncOffset: parseInt(document.getElementById('syncOffset').value) || 0,
@@ -245,6 +284,12 @@
                     payload: settings
                 }));
             }
+        }
+        
+        function showStatus(type, message) {
+            const statusEl = document.getElementById('status');
+            statusEl.className = 'show ' + type;
+            statusEl.textContent = message;
         }
 
         document.getElementById('textColor').addEventListener('change', saveSettings);
@@ -314,8 +359,11 @@
             statusEl.textContent = 'Testing server connection...';
 
             try {
-                const response = await fetch(serverUrl + '/status/sessions?X-Plex-Token=' + token, {
-                    headers: { 'Accept': 'application/json' }
+                const response = await fetch(serverUrl + '/status/sessions', {
+                    headers: { 
+                        'Accept': 'application/json',
+                        'X-Plex-Token': token
+                    }
                 });
 
                 if (!response.ok) throw new Error('HTTP ' + response.status);

--- a/install.bat
+++ b/install.bat
@@ -1,6 +1,6 @@
 @echo off
 echo =============================================
-echo  Ampdeck v1.0.1 - Stream Deck Plugin
+echo  Ampdeck v1.2.0 - Stream Deck Plugin
 echo  The Unofficial Plexamp Controller
 echo =============================================
 echo.

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "============================================="
-echo " Ampdeck v1.0.1 - Stream Deck Plugin"
+echo " Ampdeck v1.2.0 - Stream Deck Plugin"
 echo " The Unofficial Plexamp Controller"
 echo "============================================="
 echo ""


### PR DESCRIPTION
## What's Changed
###  Star Rating Feature
- New dial action: "Rotate: Star Rating" 
- Configurable half-star or full-star increment modes
- Debounced saves (2-second idle timer) for smoother UX
- Real-time visual feedback with Unicode stars
- Success/error messages on device display
- Ratings persist to Plex server

###  Bug Fixes
- Fixed overlay reversion issues (volume/rating/next/prev overlays now clear properly)
- Corrected touch strip layout geometry causing element overlap errors
- Added rating change protection from timeline poll overwrites

###  Documentation
- Updated CHANGELOG.md with v1.2.0 details
- Updated README.md with rating feature documentation

## Testing
Tested on Stream Deck+ with:
- Volume overlays ✅
- Next/Previous overlays ✅
- Rating adjustments (half & full star modes) ✅
- Rating persistence to Plex ✅
- Error handling ✅

## Technical Notes
- Uses Plex `/:/rate` endpoint
- Implements debounce pattern for API efficiency
- Unicode characters: ★ (filled), ☆ (empty), ⯨ (half)

## Installation

1. Download **`com.rackemrack.ampdeck.streamDeckPlugin`** from the [Releases](https://github.com/DreadHeadHippy/ampdeck/releases/tag/v1.2.0) page
2. Double-click the file

That's it. Stream Deck handles the rest.

Happy to make any adjustments if needed! 🤙