### PR TITLE
Adds button calls for volume up / volume down and long push for mute.

### DIFF
--- a/com.rackemrack.ampdeck.sdPlugin/manifest.json
+++ b/com.rackemrack.ampdeck.sdPlugin/manifest.json
@@ -102,6 +102,32 @@
       "PropertyInspectorPath": "pi.html"
     },
     {
+      "Name": "Volume Up",
+      "States": [
+        {
+          "Image": "imgs/volume-up-icon",
+          "ShowTitle": false
+        }
+      ],
+      "SupportedInMultiActions": false,
+      "Tooltip": "Increase volume",
+      "UUID": "com.rackemrack.ampdeck.volume-up",
+      "PropertyInspectorPath": "pi.html"
+    },
+    {
+      "Name": "Volume Down",
+      "States": [
+        {
+          "Image": "imgs/volume-down-icon",
+          "ShowTitle": false
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Tooltip": "Tap to Decrease volume, Hold to mute",
+      "UUID": "com.rackemrack.ampdeck.volume-down",
+      "PropertyInspectorPath": "pi.html"
+    },
+    {
       "Icon": "imgs/info-icon",
       "Name": "Track Info",
       "States": [


### PR DESCRIPTION
I don't have knob based stream deck so I need physical buttons for volume control. This adds the button controls and a rework of the long-press to support seek + mute. If you long press volume down it will mute volume on the player and pressing again will restore it to the last known value. I do not have icons for the buttons though - not sure how you have been making those.